### PR TITLE
feat(http): support proxy, add ProxyURI in contract.ClientConfig

### DIFF
--- a/http/contract/clientInterface.go
+++ b/http/contract/clientInterface.go
@@ -6,8 +6,9 @@ import (
 )
 
 type ClientConfig struct {
-	Timeout time.Duration
-	Cert    CertConfig
+	Timeout  time.Duration
+	Cert     CertConfig
+	ProxyURI string
 	// 如果需要定制化tls, 设置该属性, 否则请使用Cert
 	// TlsConfig *tls.Config
 }

--- a/http/helper/requestHelper.go
+++ b/http/helper/requestHelper.go
@@ -3,20 +3,20 @@ package helper
 import (
 	"bytes"
 	"encoding/xml"
+	"io"
+	http2 "net/http"
+	"strings"
+
 	"github.com/ArtisanCloud/PowerLibs/v3/http/contract"
 	"github.com/ArtisanCloud/PowerLibs/v3/http/dataflow"
 	"github.com/ArtisanCloud/PowerLibs/v3/http/drivers/http"
 	"github.com/ArtisanCloud/PowerLibs/v3/object"
-	"io"
-	"io/ioutil"
-	http2 "net/http"
-	"strings"
 )
 
 type RequestDownload struct {
-	HashType    string `json:"hash_type""`
-	HashValue   string `json:"hash_value""`
-	DownloadURL string `json:"download_url""`
+	HashType    string `json:"hash_type"`
+	HashValue   string `json:"hash_value"`
+	DownloadURL string `json:"download_url"`
 }
 
 type RequestHelper struct {
@@ -79,7 +79,7 @@ func (r *RequestHelper) ParseResponseBodyToMap(rs *http2.Response, outBody *obje
 	if err != nil {
 		return err
 	}
-	rs.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+	rs.Body = io.NopCloser(bytes.NewBuffer(b))
 
 	contentType := rs.Header.Get("Content-Type")
 
@@ -108,7 +108,7 @@ func (r *RequestHelper) ParseResponseBodyContent(rs *http2.Response, outBody int
 	if err != nil {
 		return err
 	}
-	rs.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+	rs.Body = io.NopCloser(bytes.NewBuffer(b))
 
 	contentType := rs.Header.Get("Content-Type")
 
@@ -136,7 +136,7 @@ func HttpResponseSend(rs *http2.Response, writer http2.ResponseWriter) (err erro
 	writer.WriteHeader(rs.StatusCode)
 
 	// set write body
-	body, err := ioutil.ReadAll(rs.Body)
+	body, err := io.ReadAll(rs.Body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
支持设置自定义proxy

场景:
需要在同一个服务器同时使用PowerWechat的企业微信自建应用(work)和企业微信服务商(openWork)，但是企业微信要求自建应用不能使用服务商ip, 所以需要对不同的client指定proxy.